### PR TITLE
Implemented gits untrack functionality

### DIFF
--- a/code/gits.py
+++ b/code/gits.py
@@ -18,6 +18,7 @@ from gits_delete import gits_delete
 from gits_profile import gits_set_profile
 from gits_pr_update import gits_pr_update_func
 from gits_track import gits_track
+from gits_untrack import gits_untrack
 
 
 logger_status = init_gits_logger()
@@ -95,13 +96,21 @@ gits_reset_subparser.set_defaults(func=gits_delete)
 gits_reset_subparser.add_argument('--branch', required=True, help='branch to be used')
 gits_reset_subparser.add_argument('--count', required=True, help='Last commits to be deleted')
 
-gits_add_subparser = subparsers.add_parser('track')
-gits_add_subparser.add_argument('file_names',
+gits_track_subparser = subparsers.add_parser('track')
+gits_track_subparser.add_argument('file_names',
                                 metavar='N',
                                 type=str,
                                 nargs='+',
                                 help='all file names')
-gits_add_subparser.set_defaults(func=gits_track)
+gits_track_subparser.set_defaults(func=gits_track)
+
+gits_untrack_subparser = subparsers.add_parser('untrack')
+gits_untrack_subparser.add_argument('file_names',
+                                metavar='N',
+                                type=str,
+                                nargs='+',
+                                help='all file names')
+gits_untrack_subparser.set_defaults(func=gits_untrack)
 
 args = parser.parse_args()
 args.func(args)

--- a/code/gits_untrack.py
+++ b/code/gits_untrack.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+
+import gits_logging
+from subprocess import Popen, PIPE
+
+
+def gits_untrack(args):
+    """
+    Function that moves files from staging area to the working directory.
+    Untracked files will not be considered for the upcoming commits.
+    """
+    try:
+        subprocess_command = list()
+        subprocess_command.append("git")
+        subprocess_command.append("reset")
+        subprocess_command.append("HEAD")
+        file_names_list = args.file_names
+        total_files = len(file_names_list)
+        if total_files != 0:
+            for i in range(0, total_files):
+                subprocess_command.append(file_names_list[i])
+            process = Popen(subprocess_command, stdout=PIPE, stderr=PIPE)
+            stdout, stderr = process.communicate()
+
+    except Exception as e:
+        gits_logging.gits_logger.error("gits untrack command caught an exception")
+        gits_logging.gits_logger.error("{}".format(str(e)))
+        print("ERROR: gits untrack command caught an exception")
+        print("ERROR: {}".format(str(e)))
+        return False
+
+    return True


### PR DESCRIPTION
gits untrack functionality moves file back to the working directory from the staging area. These untracked files will not be considered for the upcoming commits until they are tracked again.